### PR TITLE
Include changeset id in deletion

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,6 +172,9 @@ DB.prototype._del = function (key, opts, cb) {
         fields.refs.push.apply(fields.refs, v.refs)
       }
     })
+    if (opts.value && opts.value.changeset) {
+      fields.v = {changeset: opts.value.changeset}
+    }
     cb(null, [ { type: 'del', key: key, links: links, fields: fields } ])
   })
 }


### PR DESCRIPTION
@noffle could you review and add a test here (see the failing test in osm-p2p-server https://github.com/digidem/osm-p2p-db/compare/changeset-deletions) attempts to fix #34 
