### PR TITLE
Bugfix: delete all parents' refs before adding new refs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,7 +75,9 @@ function DB (opts) {
           if (node.value.v.members) {
             for (var i = 0; i < node.value.v.members.length; i++) {
               var member = node.value.v.members[i]
-              ops.push({ type: 'del', key: member.ref || member, rowKey: link })
+              if (typeof member === 'string') member = { ref: member }
+              if (typeof member.ref !== 'string') return
+              ops.push({ type: 'del', key: member.ref, rowKey: link })
             }
           }
           done()

--- a/index.js
+++ b/index.js
@@ -67,25 +67,27 @@ function DB (opts) {
         var done = next()
         self.log.get(link, function (err, node) {
           if (node.value.v.refs) {
-            ops = ops.concat(node.value.v.refs.map(function (ref) {
-              return { type: 'del', key: ref, rowKey: link }
-            }))
+            for (var i = 0; i < node.value.v.refs.length; i++) {
+              var ref = node.value.v.refs[i]
+              ops.push({ type: 'del', key: ref, rowKey: link })
+            }
           }
           if (node.value.v.members) {
-            ops = ops.concat(node.value.v.members.map(function (member) {
-              return { type: 'del', key: member.ref || member, rowKey: link }
-            }))
+            for (var i = 0; i < node.value.v.members.length; i++) {
+              var member = node.value.v.members[i]
+              ops.push({ type: 'del', key: member.ref || member, rowKey: link })
+            }
           }
           done()
         })
       })
       if (k) {
-        ops = ops.concat(refs.map(function (ref) {
-          return { type: 'put', key: ref, value: k }
-        }))
-        ops = ops.concat(members.map(function (member) {
-          return { type: 'put', key: member.ref || member, value: k }
-        }))
+        for (var i = 0; i < refs.length; i++) {
+          ops.push({ type: 'put', key: refs[i], value: k })
+        }
+        for (var i = 0; i < members.length; i++) {
+          ops.push({ type: 'put', key: members[i].ref || members[i], value: k })
+        }
       }
     }
   })

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var EventEmitter = require('events').EventEmitter
 var hex2dec = require('./lib/hex2dec.js')
 var lock = require('mutexify')
 var defined = require('defined')
+var after = require('after-all')
 
 module.exports = DB
 inherits(DB, EventEmitter)
@@ -51,38 +52,52 @@ function DB (opts) {
   self.refs = join({
     log: self.log,
     db: sub(self.db, 'r'),
-    map: function (row) {
+    map: function (row, cb) {
       if (!row.value) return
       var k = row.value.k, v = row.value.v || {}
       var ops = []
+      var next = after(function () {
+        cb(null, ops)
+      })
+
+      // Update refs
       var refs = v.refs || row.value.refs || []
-      refs.forEach(function (ref) {
-        row.links.forEach(function (link) {
-          ops.push({ type: 'del', key: ref, rowKey: link })
-        })
-        if (k) ops.push({ type: 'put', key: ref, value: k })
-      })
       var members = v.members || row.value.members || []
-      members.forEach(function (member) {
-        if (typeof member === 'string') member = { ref: member }
-        if (typeof member.ref !== 'string') return
-        row.links.forEach(function (link) {
-          ops.push({ type: 'del', key: member.ref, rowKey: link })
+      row.links.forEach(function (link) {
+        var done = next()
+        self.log.get(link, function (err, node) {
+          if (node.value.v.refs) {
+            ops = ops.concat(node.value.v.refs.map(function (ref) {
+              return { type: 'del', key: ref, rowKey: link }
+            }))
+          }
+          if (node.value.v.members) {
+            ops = ops.concat(node.value.v.members.map(function (member) {
+              return { type: 'del', key: member.ref || member, rowKey: link }
+            }))
+          }
+          done()
         })
-        if (k) ops.push({ type: 'put', key: member.ref, value: k })
       })
-      return ops
+      if (k) {
+        ops = ops.concat(refs.map(function (ref) {
+          return { type: 'put', key: ref, value: k }
+        }))
+        ops = ops.concat(members.map(function (member) {
+          return { type: 'put', key: member.ref || member, value: k }
+        }))
+      }
     }
   })
   self.refs.on('error', function (err) { self.emit('error', err) })
   self.changeset = join({
     log: self.log,
     db: sub(self.db, 'c'),
-    map: function (row) {
-      if (!row.value) return
+    map: function (row, cb) {
+      if (!row.value) return cb()
       var v = row.value.v
-      if (!v || !v.changeset) return
-      return { type: 'put', key: v.changeset, value: 0 }
+      if (!v || !v.changeset) return cb()
+      return cb(null, { type: 'put', key: v.changeset, value: 0 })
     }
   })
   self.changeset.on('error', function (err) { self.emit('error', err) })

--- a/package.json
+++ b/package.json
@@ -24,11 +24,12 @@
     "tape": "^4.3.0"
   },
   "dependencies": {
+    "after-all": "^2.0.2",
     "base-convertor": "^1.1.0",
     "defined": "^1.0.0",
     "has": "^1.0.1",
     "hyperkv": "^2.0.1",
-    "hyperlog-join": "^1.3.1",
+    "hyperlog-join": "^2.0.0",
     "hyperlog-kdb-index": "^4.0.0",
     "inherits": "^2.0.1",
     "kdb-tree-store": "^3.0.2",

--- a/test/refbug.js
+++ b/test/refbug.js
@@ -63,6 +63,164 @@ test('refbug', function (t) {
   }
 })
 
+test('refbug 2: nodes referred to by old versions of a way are retained', function (t) {
+  var osm = osmdb({
+    log: hyperlog(memdb(), { valueEncoding: 'json' }),
+    db: memdb(),
+    store: fdstore(4096, storefile)
+  })
+
+  var batch = [
+    { type: 'put', key: 'A', value: { type: 'node', lat: 64.5, lon: -147.3 } },
+    { type: 'put', key: 'B', value: { type: 'node', lat: 1.0, lon: 2.0 } },
+    { type: 'put', key: 'C', value: { type: 'node', lat: 3.0, lon: 4.0 } },
+    { type: 'put', key: 'D', value: { type: 'node', lat: 64.123, lon: -147.56 } },
+    { type: 'put', key: 'F', value: { type: 'way', refs: [ 'A', 'B' ] } }
+  ]
+  var versions = {}
+  var way
+
+  osm.batch(batch, function (err, nodes) {
+    t.error(err)
+    nodes.forEach(function (node) {
+      versions[node.value.k] = node.key
+    })
+    way = versions.F
+    osm.ready(ready)
+  })
+
+  var pending = 4
+  function ready () {
+    osm.refs.list('A', function (err, refs) {
+      t.error(err)
+      t.deepEqual(refs.map(mapKeys), [way], 'A referenced by original way')
+      done()
+    })
+    osm.refs.list('B', function (err, refs) {
+      t.error(err)
+      t.deepEqual(refs.map(mapKeys), [way], 'B referenced by original way')
+      done()
+    })
+    osm.refs.list('C', function (err, refs) {
+      t.error(err)
+      t.deepEqual(refs.map(mapKeys), [], 'No ways should reference C')
+      done()
+    })
+    osm.refs.list('D', function (err, refs) {
+      t.error(err)
+      t.deepEqual(refs.map(mapKeys), [], 'No ways should reference D')
+      done()
+    })
+  }
+
+  function done () {
+    if (--pending === 0) {
+      nextStep()
+    }
+  }
+
+  function nextStep () {
+    // modify original way
+    var way1 = { type: 'way', refs: [ 'A', 'C' ] }
+    osm.put('F', way1, {links: [versions.F]}, function (err, doc) {
+      t.error(err)
+      osm.ready(ready)
+    })
+    function ready () {
+      osm.refs.list('B', function (err, refs) {
+        t.error(err)
+        t.deepEqual(refs.map(mapKeys), [], 'B no longer referenced')
+        t.end()
+      })
+    }
+  }
+})
+
+test('refbug 2: ways referred to by old versions of a relation are retained', function (t) {
+  var osm = osmdb({
+    log: hyperlog(memdb(), { valueEncoding: 'json' }),
+    db: memdb(),
+    store: fdstore(4096, storefile)
+  })
+
+  var batch = [
+    { type: 'put', key: 'A', value: { type: 'node', lat: 64.5, lon: -147.3 } },
+    { type: 'put', key: 'B', value: { type: 'node', lat: 1.0, lon: 2.0 } },
+    { type: 'put', key: 'C', value: { type: 'node', lat: 3.0, lon: 4.0 } },
+    { type: 'put', key: 'D', value: { type: 'node', lat: 64.123, lon: -147.56 } },
+    { type: 'put', key: 'E', value: {
+      type: 'relation', members: [
+        { type: 'node', ref: 'A' },
+        { type: 'node', ref: 'B' }
+      ] }
+    }
+  ]
+  var versions = {}
+  var rel
+
+  osm.batch(batch, function (err, nodes) {
+    t.error(err)
+    nodes.forEach(function (node) {
+      versions[node.value.k] = node.key
+    })
+    rel = versions.E
+    osm.ready(ready)
+  })
+
+  var pending = 4
+  function ready () {
+    osm.refs.list('A', function (err, refs) {
+      t.error(err)
+      t.deepEqual(refs.map(mapKeys), [rel], 'A referenced by original relation')
+      done()
+    })
+    osm.refs.list('B', function (err, refs) {
+      t.error(err)
+      t.deepEqual(refs.map(mapKeys), [rel], 'B referenced by original relation')
+      done()
+    })
+    osm.refs.list('C', function (err, refs) {
+      t.error(err)
+      t.deepEqual(refs.map(mapKeys), [], 'No relations should reference C')
+      done()
+    })
+    osm.refs.list('D', function (err, refs) {
+      t.error(err)
+      t.deepEqual(refs.map(mapKeys), [], 'No relations should reference D')
+      done()
+    })
+  }
+
+  function done () {
+    if (--pending === 0) {
+      nextStep()
+    }
+  }
+
+  function nextStep () {
+    // modify original way
+    var rel1 = { type: 'relation', members: [
+        { type: 'node', ref: 'A' },
+        { type: 'node', ref: 'C' }
+      ] }
+    osm.put('E', rel1, {links: [versions.E]}, function (err, doc) {
+      t.error(err)
+      osm.ready(ready)
+    })
+    function ready () {
+      osm.refs.list('B', function (err, refs) {
+        t.error(err)
+        t.deepEqual(refs.map(mapKeys), [], 'B no longer referenced')
+        t.end()
+      })
+    }
+  }
+})
+
 function eqtype (t) {
   return function (node) { return node.type === t }
+}
+
+function mapKeys (ref) {
+  return ref.key
 }


### PR DESCRIPTION
This addresses the case where a way or relation references e.g. `W1 = [A, B, C]` and is then modified just reference `W2 = [A, C]`. In this case, the backwards reference from `B` to `W1` would be retained. This fix ensures that all of old parents linked to from a new OSM document are purged.

*N.B.*: depends on `hyperlog-join@2.0.0` being published. See https://github.com/substack/hyperlog-join/pull/1