### PR TITLE
Surface document deletions through the API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,8 +214,6 @@ Get a document as `cb(err, docs)` by its OSM `id`.
 document has been deleted, it will only have the properties `{ id: <osm-id>,
 version: <osm-version>, deleted: true}`.
 
-The options `opts` are passed to the underlying [hyperkv][4] instance.
-
 ### osm.query(q, opts, cb)
 
 Query for all nodes, ways, and relations in the query given by the array `q`.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,9 @@ Each `row` in `rows` should have:
 
 Get a document as `cb(err, docs)` by its OSM `id`.
 
-`docs` is an object mapping hyperlog hashes to current document values.
+`docs` is an object mapping hyperlog hashes to current document values. If a
+document has been deleted, it will only have the properties `{ id: <osm-id>,
+version: <osm-version>, deleted: true}`.
 
 The options `opts` are passed to the underlying [hyperkv][4] instance.
 
@@ -220,9 +222,10 @@ Query for all nodes, ways, and relations in the query given by the array `q`.
 Queries are arrays of `[[minLat,maxLat],[minLon,maxLon]]` specifying a bounding
 box.
 
-`cb(err, res)` fires with an array of results `res`. Each result is the
-document augmented with an `id` property and a `version` property that is the
-hash key from the underlying hyperlog.
+`cb(err, res)` fires with an array of results `res`. Each result is the document
+augmented with an `id` property and a `version` property that is the hash key
+from the underlying hyperlog. If a document has been deleted, it will only have
+the properties `{ id: <osm-id>, version: <osm-version>, deleted: true}`.
 
 Optionally:
 

--- a/index.js
+++ b/index.js
@@ -258,6 +258,10 @@ DB.prototype._getDocumentDeletionBatchOps = function (id, opts, cb) {
         if (!fields.refs) fields.refs = []
         fields.refs.push.apply(fields.refs, v.refs)
       }
+      if (Array.isArray(v.members)) {
+        if (!fields.members) fields.members = []
+        fields.members.push.apply(fields.members, v.members)
+      }
     })
     cb(null, [ { type: 'del', key: id, links: links, fields: fields } ])
   }

--- a/index.js
+++ b/index.js
@@ -179,12 +179,18 @@ DB.prototype.del = function (key, opts, cb) {
   }
   if (!opts) opts = {}
   cb = once(cb || noop)
-  self._getDocumentDeletionBatchOps(key, opts, function (err, rows) {
-    if (err) return cb(err)
-    self.batch(rows, opts, function (err, nodes) {
-      if (err) cb(err)
-      else cb(null, nodes[0])
-    })
+
+  var rows = [
+    {
+      type: 'del',
+      key: key,
+      links: opts.links || []
+    }
+  ]
+
+  self.batch(rows, opts, function (err, nodes) {
+    if (err) cb(err)
+    else cb(null, nodes[0])
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -339,7 +339,10 @@ DB.prototype._onpt = function (pt, seen, cb) {
             deleted: true
           }
         }
-        addDoc(doc.value.k || doc.value.d, link, doc.value.v)
+        // TODO: open up this if() statement to expose deletions
+        if (doc.value.k) {
+          addDoc(doc.value.k || doc.value.d, link, doc.value.v)
+        }
         if (--pending === 0) cb(null, res)
       })
       pending++

--- a/index.js
+++ b/index.js
@@ -392,8 +392,11 @@ DB.prototype._collectNodeAndReferers = function (version, seenAccum, cb) {
   var selfNode
   var originalNode
   self.log.get(version, function (err, node) {
-    selfNode = node
-    originalNode = node
+    // TODO: handle error
+    if (!err) {
+      selfNode = node
+      originalNode = node
+    }
     self._getReferers(version, onLinks)
   })
 
@@ -413,30 +416,36 @@ DB.prototype._collectNodeAndReferers = function (version, seenAccum, cb) {
       seenAccum[link] = true
       pending++
       self.log.get(link, function (err, node) {
-        addDocFromNode(node)
-        if (node && node.value && node.value.k && node.value.v) {
-          // Add the original node if a referer is a relation.
-          if (originalNode && !seenAccum[originalNode.key] && node.value.v.type === 'relation') {
-            addDocFromNode(originalNode)
-            seenAccum[originalNode.key] = true
-            originalNode = null
-          }
+        // TODO: handle error
+        if (!err) {
+          addDocFromNode(node)
+          if (node && node.value && node.value.k && node.value.v) {
+            // Add the original node if a referer is a relation.
+            if (originalNode && !seenAccum[originalNode.key] && node.value.v.type === 'relation') {
+              addDocFromNode(originalNode)
+              seenAccum[originalNode.key] = true
+              originalNode = null
+            }
 
-          pending++
-          self.get(node.value.k, function (err, docs) {
-            if (err) return cb(err)
-            Object.keys(docs).forEach(function (key) {
-              addDoc(node.value.k, key, docs[key])
+            pending++
+            self.get(node.value.k, function (err, docs) {
+              if (err) return cb(err)
+              Object.keys(docs).forEach(function (key) {
+                addDoc(node.value.k, key, docs[key])
+              })
+              if (--pending === 0) cb(null, res)
             })
-            if (--pending === 0) cb(null, res)
-          })
+          }
         }
         if (--pending === 0) cb(null, res)
       })
       pending++
       self._getReferers(link, function (err, links2) {
-        originalNode = null
-        onLinks(err, links2)
+        // TODO: handle error
+        if (!err) {
+          originalNode = null
+          onLinks(err, links2)
+        }
       })
     })
 
@@ -472,11 +481,14 @@ DB.prototype._collectNodeAndReferers = function (version, seenAccum, cb) {
       seenAccum[ref] = true
       pending++
       self.get(ref, function (err, docs) {
-        Object.keys(docs || {}).forEach(function (key) {
-          if (seenAccum[key]) return
-          seenAccum[key] = true
-          addDoc(ref, key, docs[key])
-        })
+        // TODO: handle error
+        if (!err) {
+          Object.keys(docs || {}).forEach(function (key) {
+            if (seenAccum[key]) return
+            seenAccum[key] = true
+            addDoc(ref, key, docs[key])
+          })
+        }
         if (--pending === 0) cb(null, res)
       })
     })

--- a/index.js
+++ b/index.js
@@ -276,7 +276,7 @@ DB.prototype.get = function (key, opts, cb) {
     cb = opts
     opts = {}
   }
-  this.kv.get(key, opts, function (err, docs) {
+  this.kv.get(key, function (err, docs) {
     if (err) return cb(err)
     docs = mapObj(docs, function (version, value) {
       if (value.deleted) {

--- a/index.js
+++ b/index.js
@@ -188,16 +188,16 @@ DB.prototype.del = function (key, opts, cb) {
   })
 }
 
-// OsmVersion, Opts -> [OsmBatchOp]
-DB.prototype._getDocumentDeletionBatchOps = function (key, opts, cb) {
+// OsmId, Opts -> [OsmBatchOp]
+DB.prototype._getDocumentDeletionBatchOps = function (id, opts, cb) {
   var self = this
-  self.kv.get(key, function (err, docs) {
+  self.kv.get(id, function (err, docs) {
     if (err) return cb(err)
 
     docs = mapObj(docs, function (version, value) {
       if (value.deleted) {
         return {
-          id: key,
+          id: id,
           version: version,
           deleted: true
         }
@@ -219,7 +219,7 @@ DB.prototype._getDocumentDeletionBatchOps = function (key, opts, cb) {
         fields.refs.push.apply(fields.refs, v.refs)
       }
     })
-    cb(null, [ { type: 'del', key: key, links: links, fields: fields } ])
+    cb(null, [ { type: 'del', key: id, links: links, fields: fields } ])
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -347,13 +347,15 @@ DB.prototype.query = function (q, opts, cb) {
   function onquery (err, pts) {
     if (err) return cb(err)
     var pending = 1, seen = {}
-    pts.forEach(function (pt) {
+    for (var i = 0; i < pts.length; i++) {
+      var pt = pts[i]
       pending++
       self._collectNodeAndReferers(kdbPointToVersion(pt), seen, function (err, r) {
+        if (err) return cb(err)
         if (r) res = res.concat(r)
         if (--pending === 0) done()
       })
-    })
+    }
     if (--pending === 0) done()
   }
   function done () {
@@ -493,6 +495,7 @@ DB.prototype.queryStream = function (q, opts) {
     next = once(next)
     var tr = this
     self._collectNodeAndReferers(kdbPointToVersion(row), seen, function (err, res) {
+      if (err) return next()
       if (res) res.forEach(function (r) {
         tr.push(r)
       })
@@ -503,6 +506,7 @@ DB.prototype.queryStream = function (q, opts) {
     next = once(next)
     var tr = this
     self._collectNodeAndReferers(kdbPointToVersion(row), seen, function (err, res) {
+      if (err) return next()
       if (res) res.forEach(function (r) {
         if (r.type === 'node') tr.push(r)
         else queue.push(r)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var hex2dec = require('./lib/hex2dec.js')
 var lock = require('mutexify')
 var defined = require('defined')
 var after = require('after-all')
-var mapLimit = require('map-limit')
+var mapLimit = require('async/mapLimit')
 
 module.exports = DB
 inherits(DB, EventEmitter)

--- a/index.js
+++ b/index.js
@@ -200,15 +200,15 @@ DB.prototype._getDocumentDeletionBatchOps = function (id, opts, cb) {
   self.kv.get(id, function (err, docs) {
     if (err) return cb(err)
 
-    docs = mapObj(docs, function (version, value) {
-      if (value.deleted) {
+    docs = mapObj(docs, function (version, doc) {
+      if (doc.deleted) {
         return {
           id: id,
           version: version,
           deleted: true
         }
       } else {
-        return value.value
+        return doc.value
       }
     })
 
@@ -278,15 +278,15 @@ DB.prototype.get = function (key, opts, cb) {
   }
   this.kv.get(key, function (err, docs) {
     if (err) return cb(err)
-    docs = mapObj(docs, function (version, value) {
-      if (value.deleted) {
+    docs = mapObj(docs, function (version, doc) {
+      if (doc.deleted) {
         return {
           id: key,
           version: version,
           deleted: true
         }
       } else {
-        return value.value
+        return doc.value
       }
     })
 

--- a/index.js
+++ b/index.js
@@ -51,7 +51,6 @@ function DB (opts) {
         var pts = row.value.points.map(ptf)
         next(null, { type: 'put', points: pts })
       } else next()
-      function ptf (x) { return [ x.lat, x.lon ] }
     }
   })
   self.kdb.on('error', function (err) { self.emit('error', err) })
@@ -563,3 +562,6 @@ function mapObj (obj, fn) {
 function kdbPointToVersion (pt) {
   return pt.value.toString('hex')
 }
+
+// {lat: Number, lon: Number} -> [Number, Number]
+function ptf (x) { return [ x.lat, x.lon ] }

--- a/index.js
+++ b/index.js
@@ -63,8 +63,8 @@ function DB (opts) {
       var k = row.value.k, v = row.value.v || {}
       var d = row.value.d
       var ops = []
-      var next = after(function () {
-        cb(null, ops)
+      var next = after(function (err) {
+        cb(err, ops)
       })
 
       // Delete the old refs for this osm document ID
@@ -73,6 +73,7 @@ function DB (opts) {
       row.links.forEach(function (link) {
         var done = next()
         self.log.get(link, function (err, node) {
+          if (err) return done(err)
           if (node.value.v.refs) {
             for (var i = 0; i < node.value.v.refs.length; i++) {
               var ref = node.value.v.refs[i]

--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ DB.prototype.del = function (key, opts, cb) {
     {
       type: 'del',
       key: key,
-      links: opts.links || undefined
+      links: opts.links
     }
   ]
 
@@ -284,6 +284,13 @@ DB.prototype.batch = function (rows, opts, cb) {
       if (!key) {
         key = row.key = hex2dec(randomBytes(8).toString('hex'))
       }
+
+      if (row.links && !Array.isArray(row.links)) {
+        return cb(new Error('row has a "links" field that isnt an array'))
+      } else if (!row.links && row.links !== undefined) {
+        return cb(new Error('row has a "links" field that is non-truthy but not undefined'))
+      }
+
       if (row.type === 'put') {
         batch.push(row)
         if (--pending === 0) done()

--- a/index.js
+++ b/index.js
@@ -355,10 +355,7 @@ DB.prototype._onpt = function (pt, seen, cb) {
             deleted: true
           }
         }
-        // TODO: open up this if() statement to expose deletions
-        if (doc.value.k) {
-          addDoc(doc.value.k || doc.value.d, link, doc.value.v)
-        }
+        addDoc(doc.value.k || doc.value.d, link, doc.value.v)
         if (--pending === 0) cb(null, res)
       })
       pending++
@@ -370,9 +367,6 @@ DB.prototype._onpt = function (pt, seen, cb) {
   })
 
   function addDoc (id, key, doc) {
-    // For now, filter out deleted documents.
-    if (doc.deleted) return
-
     if (!added.hasOwnProperty(key)) {
       res.push(xtend(doc, {
         id: id,

--- a/index.js
+++ b/index.js
@@ -43,8 +43,8 @@ function DB (opts) {
       if (v && v.lat !== undefined && v.lon !== undefined) {
         next(null, { type: 'put', point: ptf(v) })
       } else if (d && Array.isArray(row.value.points)) {
-        var pt = row.value.points.map(ptf)[0]
-        next(null, { type: 'put', point: pt })
+        var pts = row.value.points.map(ptf)
+        next(null, { type: 'put', points: pts })
       } else next()
       function ptf (x) { return [ x.lat, x.lon ] }
     }
@@ -315,9 +315,11 @@ DB.prototype._onpt = function (pt, seen, cb) {
     if (doc && doc.value && doc.value.k && doc.value.v) {
       addDoc(doc.value.k, link, doc.value.v)
     } else if (doc && doc.value && doc.value.d && doc.value.points) {
-      var pt = doc.value.points[0]
-      pt.deleted = true
-      addDoc(doc.value.d, link, pt)
+      for (var i = 0; i < doc.value.points.length; i++) {
+        var pt = doc.value.points[i]
+        pt.deleted = true
+        addDoc(doc.value.d, link, pt)
+      }
     }
     if (--pending === 0) cb(null, res)
   })

--- a/index.js
+++ b/index.js
@@ -346,7 +346,9 @@ DB.prototype._collectNodeAndReferers = function (version, seenAccum, cb) {
     if (--pending === 0) cb(null, res)
   })
 
-  self._getReferers(version, function onlinks (err, links) {
+  self._getReferers(version, onLinks)
+
+  function onLinks (err, links) {
     if (!links) links = []
     links.forEach(function (link) {
       if (has(seenAccum, link)) return
@@ -367,12 +369,12 @@ DB.prototype._collectNodeAndReferers = function (version, seenAccum, cb) {
         if (--pending === 0) cb(null, res)
       })
       pending++
-      self._getReferers(link, function (err, links) {
-        onlinks(err, links)
+      self._getReferers(link, function (err, links2) {
+        onLinks(err, links2)
       })
     })
     if (--pending === 0) cb(null, res)
-  })
+  }
 
   function addDocFromNode (node) {
     if (node && node.value && node.value.k && node.value.v) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "async": "^2.3.0",
     "base-convertor": "^1.1.0",
     "defined": "^1.0.0",
-    "has": "^1.0.1",
     "hyperkv": "^2.0.1",
     "hyperlog-join": "^2.0.0",
     "hyperlog-kdb-index": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "after-all": "^2.0.2",
+    "async": "^2.3.0",
     "base-convertor": "^1.1.0",
     "defined": "^1.0.0",
     "has": "^1.0.1",
@@ -33,7 +34,6 @@
     "hyperlog-kdb-index": "^4.0.0",
     "inherits": "^2.0.1",
     "kdb-tree-store": "^3.0.2",
-    "map-limit": "0.0.1",
     "mutexify": "^1.1.0",
     "once": "^1.3.3",
     "randombytes": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "hyperlog-kdb-index": "^4.0.0",
     "inherits": "^2.0.1",
     "kdb-tree-store": "^3.0.2",
+    "map-limit": "0.0.1",
     "mutexify": "^1.1.0",
     "once": "^1.3.3",
     "randombytes": "2.0.1",

--- a/test/del.js
+++ b/test/del.js
@@ -67,7 +67,10 @@ test('del', function (t) {
       { type: 'node', lat: 64.2, lon: -146.5,
         id: names.C, version: versions.C },
       { type: 'way', refs: [ names.A, names.B, names.C ],
-        id: names.F, version: versions.F }
+        id: names.F, version: versions.F },
+      { deleted: true, id: names.D, version: versions.H,
+        lat: 64.123, lon: -147.56 },
+      { deleted: true, id: names.E, version: versions.G }
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
       t.ifError(err)
@@ -86,7 +89,8 @@ test('del', function (t) {
       { type: 'node', lat: 64.2, lon: -146.5,
         id: names.C, version: versions.C },
       { type: 'way', refs: [ names.A, names.B, names.C ],
-        id: names.F, version: versions.F }
+        id: names.F, version: versions.F },
+      { deleted: true, id: names.E, version: versions.G }
     ].sort(idcmp)
     osm.query(q1, function (err, res) {
       t.ifError(err)

--- a/test/del.js
+++ b/test/del.js
@@ -68,8 +68,7 @@ test('del', function (t) {
         id: names.C, version: versions.C },
       { type: 'way', refs: [ names.A, names.B, names.C ],
         id: names.F, version: versions.F },
-      { deleted: true, id: names.D, version: versions.H,
-        lat: 64.123, lon: -147.56 },
+      { deleted: true, id: names.D, version: versions.H },
       { deleted: true, id: names.E, version: versions.G }
     ].sort(idcmp)
     osm.query(q0, function (err, res) {

--- a/test/del_batch.js
+++ b/test/del_batch.js
@@ -53,6 +53,8 @@ test('del batch', function (t) {
         id: 'B', version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
         id: 'C', version: versions.C },
+      { deleted: true, lat: 64.123, lon: -147.56,
+        id: 'D', version: deletions.D },
       { deleted: true,
         id: 'E', version: deletions.E },
       { type: 'way', refs: [ 'A', 'B', 'C' ],
@@ -66,6 +68,7 @@ test('del batch', function (t) {
       t.error(err)
       t.deepEqual(res.sort(idcmp), ex0, 'full coverage stream')
     })
+
     var q1 = [[62,64],[-149.5,-147.5]]
     var ex1 = [
       { type: 'node', lat: 64.5, lon: -147.3,
@@ -74,6 +77,8 @@ test('del batch', function (t) {
         id: 'B', version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
         id: 'C', version: versions.C },
+      { deleted: true,
+        id: 'E', version: deletions.E },
       { type: 'way', refs: [ 'A', 'B', 'C' ],
         id: 'F', version: versions.F }
     ].sort(idcmp)

--- a/test/del_batch.js
+++ b/test/del_batch.js
@@ -30,6 +30,7 @@ test('del batch', function (t) {
     { type: 'del', key: 'D' }
   ]
   var versions = {}
+  var deletions = {}
   osm.batch(batch0, function (err, nodes) {
     t.error(err)
     nodes.forEach(function (node) {
@@ -37,6 +38,9 @@ test('del batch', function (t) {
     })
     osm.batch(batch1, function (err, nodes) {
       t.error(err)
+      nodes.forEach(function (node) {
+        deletions[node.value.d] = node.key
+      })
       ready()
     })
   })
@@ -49,6 +53,8 @@ test('del batch', function (t) {
         id: 'B', version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
         id: 'C', version: versions.C },
+      { deleted: true,
+        id: 'E', version: deletions.E },
       { type: 'way', refs: [ 'A', 'B', 'C' ],
         id: 'F', version: versions.F }
     ].sort(idcmp)

--- a/test/del_batch.js
+++ b/test/del_batch.js
@@ -53,10 +53,8 @@ test('del batch', function (t) {
         id: 'B', version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
         id: 'C', version: versions.C },
-      { deleted: true, lat: 64.123, lon: -147.56,
-        id: 'D', version: deletions.D },
-      { deleted: true,
-        id: 'E', version: deletions.E },
+      { deleted: true, id: 'D', version: deletions.D },
+      { deleted: true, id: 'E', version: deletions.E },
       { type: 'way', refs: [ 'A', 'B', 'C' ],
         id: 'F', version: versions.F }
     ].sort(idcmp)
@@ -77,8 +75,7 @@ test('del batch', function (t) {
         id: 'B', version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
         id: 'C', version: versions.C },
-      { deleted: true,
-        id: 'E', version: deletions.E },
+      { deleted: true, id: 'E', version: deletions.E },
       { type: 'way', refs: [ 'A', 'B', 'C' ],
         id: 'F', version: versions.F }
     ].sort(idcmp)

--- a/test/del_node.js
+++ b/test/del_node.js
@@ -56,7 +56,7 @@ test('del node', function (t) {
     var q0 = [[63,65],[-148,-146]]
     var ex0 = [
       { type: 'node', lat: 63.9, lon: -147.6, id: names.B, version: versions.B },
-      { deleted: true, lat: 64.5, lon: -147.3, id: names.A, version: versions.C },
+      { deleted: true, id: names.A, version: versions.C },
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
       t.ifError(err)

--- a/test/del_node.js
+++ b/test/del_node.js
@@ -56,7 +56,7 @@ test('del node', function (t) {
     var q0 = [[63,65],[-148,-146]]
     var ex0 = [
       { type: 'node', lat: 63.9, lon: -147.6, id: names.B, version: versions.B },
-      { deleted: true, id: names.A, version: versions.C },
+      { deleted: true, lat: 64.5, lon: -147.3, id: names.A, version: versions.C },
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
       t.ifError(err)

--- a/test/del_node.js
+++ b/test/del_node.js
@@ -55,8 +55,8 @@ test('del node', function (t) {
   function ready () {
     var q0 = [[63,65],[-148,-146]]
     var ex0 = [
-      { type: 'node', lat: 63.9, lon: -147.6,
-        id: names.B, version: versions.B },
+      { type: 'node', lat: 63.9, lon: -147.6, id: names.B, version: versions.B },
+      { deleted: true, id: names.A, version: versions.C },
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
       t.ifError(err)

--- a/test/del_node_in_way.js
+++ b/test/del_node_in_way.js
@@ -116,6 +116,113 @@ test('delete a node from a way', function (t) {
   }
 })
 
+test('proper way with deleted nodes', function (t) {
+  t.plan(19)
+  var osm = osmdb({
+    log: hyperlog(memdb(), { valueEncoding: 'json' }),
+    db: memdb(),
+    store: fdstore(4096, storefile)
+  })
+  var docs = {
+    A: { type: 'node', lat: 64.5, lon: -147.3 },
+    B: { type: 'node', lat: 63.9, lon: -147.6 },
+    C: { type: 'node', lat: 64.2, lon: -146.5 },
+    D: { type: 'node', lat: 64.123, lon: -147.56 },
+    E: { type: 'way', refs: [ 'A', 'B', 'C', 'D' ] },
+    G: { d: 'D' }
+  }
+  var names = {}
+  var nodes = {}
+  var versions = {}
+
+  var keys = Object.keys(docs).sort()
+  ;(function next () {
+    if (keys.length === 0) return ready()
+    var key = keys.shift()
+    var doc = docs[key]
+    if (doc.refs) {
+      doc.refs = doc.refs.map(function (ref) { return names[ref] })
+    }
+    if (doc.d) {
+      osm.del(names[doc.d], function (err, node) {
+        t.ifError(err)
+        versions[key] = node.key
+        nodes[doc.d] = node
+        next()
+      })
+    } else if (doc.m) {
+      doc.v.refs = doc.v.refs.map(function (ref) { return names[ref] })
+      osm.put(names[doc.m], doc.v, function (err, node) {
+        t.ifError(err)
+        versions[key] = node.key
+        nodes[names[doc.m]] = node
+        next()
+      })
+    } else {
+      osm.create(doc, function (err, k, node) {
+        t.ifError(err)
+        names[key] = k
+        versions[key] = node.key
+        nodes[k] = node
+        next()
+      })
+    }
+  })()
+
+  function ready () {
+    var q0 = [[63,65],[-148,-146]]
+    var ex0 = [
+      { type: 'node', lat: 64.5, lon: -147.3,
+        id: names.A, version: versions.A },
+      { type: 'node', lat: 63.9, lon: -147.6,
+        id: names.B, version: versions.B },
+      { type: 'node', lat: 64.2, lon: -146.5,
+        id: names.C, version: versions.C },
+      { deleted: true, id: names.D, version: versions.G },
+      { type: 'way', refs: [ names.A, names.B, names.C ],
+        id: names.E, version: versions.F }
+    ].sort(idcmp)
+    osm.query(q0, function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex0, 'full coverage query')
+    })
+    collect(osm.queryStream(q0), function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex0, 'full coverage stream')
+    })
+    var q1 = [[62,64],[-149.5,-147.5]]
+    var ex1 = [
+      { type: 'node', lat: 64.5, lon: -147.3,
+        id: names.A, version: versions.A },
+      { type: 'node', lat: 63.9, lon: -147.6,
+        id: names.B, version: versions.B },
+      { type: 'node', lat: 64.2, lon: -146.5,
+        id: names.C, version: versions.C },
+      { deleted: true, id: names.D, version: versions.G },
+      { type: 'way', refs: [ names.A, names.B, names.C ],
+        id: names.E, version: versions.F }
+    ].sort(idcmp)
+    osm.query(q1, function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex1, 'partial coverage query')
+    })
+    collect(osm.queryStream(q1), function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex1, 'partial coverage stream')
+    })
+    var q2 = [[62,64],[-147,-145]]
+    var ex2 = []
+    osm.query(q2, function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex2, 'empty coverage query')
+    })
+    collect(osm.queryStream(q2), function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex2, 'empty coverage stream')
+    })
+  }
+})
+
 function idcmp (a, b) {
   return a.id < b.id ? -1 : 1
 }

--- a/test/del_node_in_way.js
+++ b/test/del_node_in_way.js
@@ -75,8 +75,7 @@ test('delete a node from a way', function (t) {
         id: names.C, version: versions.C },
       { type: 'way', refs: [ names.A, names.B, names.C ],
         id: names.E, version: versions.F },
-      { deleted: true, id: names.D, version: versions.G,
-        lat: 64.123, lon: -147.56 },
+      { deleted: true, id: names.D, version: versions.G },
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
       t.ifError(err)

--- a/test/del_node_in_way.js
+++ b/test/del_node_in_way.js
@@ -74,7 +74,9 @@ test('delete a node from a way', function (t) {
       { type: 'node', lat: 64.2, lon: -146.5,
         id: names.C, version: versions.C },
       { type: 'way', refs: [ names.A, names.B, names.C ],
-        id: names.E, version: versions.F }
+        id: names.E, version: versions.F },
+      { deleted: true, id: names.D, version: versions.G,
+        lat: 64.123, lon: -147.56 },
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
       t.ifError(err)
@@ -92,113 +94,6 @@ test('delete a node from a way', function (t) {
         id: names.B, version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
         id: names.C, version: versions.C },
-      { type: 'way', refs: [ names.A, names.B, names.C ],
-        id: names.E, version: versions.F }
-    ].sort(idcmp)
-    osm.query(q1, function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex1, 'partial coverage query')
-    })
-    collect(osm.queryStream(q1), function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex1, 'partial coverage stream')
-    })
-    var q2 = [[62,64],[-147,-145]]
-    var ex2 = []
-    osm.query(q2, function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex2, 'empty coverage query')
-    })
-    collect(osm.queryStream(q2), function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex2, 'empty coverage stream')
-    })
-  }
-})
-
-test('proper way with deleted nodes', function (t) {
-  t.plan(19)
-  var osm = osmdb({
-    log: hyperlog(memdb(), { valueEncoding: 'json' }),
-    db: memdb(),
-    store: fdstore(4096, storefile)
-  })
-  var docs = {
-    A: { type: 'node', lat: 64.5, lon: -147.3 },
-    B: { type: 'node', lat: 63.9, lon: -147.6 },
-    C: { type: 'node', lat: 64.2, lon: -146.5 },
-    D: { type: 'node', lat: 64.123, lon: -147.56 },
-    E: { type: 'way', refs: [ 'A', 'B', 'C', 'D' ] },
-    G: { d: 'D' }
-  }
-  var names = {}
-  var nodes = {}
-  var versions = {}
-
-  var keys = Object.keys(docs).sort()
-  ;(function next () {
-    if (keys.length === 0) return ready()
-    var key = keys.shift()
-    var doc = docs[key]
-    if (doc.refs) {
-      doc.refs = doc.refs.map(function (ref) { return names[ref] })
-    }
-    if (doc.d) {
-      osm.del(names[doc.d], function (err, node) {
-        t.ifError(err)
-        versions[key] = node.key
-        nodes[doc.d] = node
-        next()
-      })
-    } else if (doc.m) {
-      doc.v.refs = doc.v.refs.map(function (ref) { return names[ref] })
-      osm.put(names[doc.m], doc.v, function (err, node) {
-        t.ifError(err)
-        versions[key] = node.key
-        nodes[names[doc.m]] = node
-        next()
-      })
-    } else {
-      osm.create(doc, function (err, k, node) {
-        t.ifError(err)
-        names[key] = k
-        versions[key] = node.key
-        nodes[k] = node
-        next()
-      })
-    }
-  })()
-
-  function ready () {
-    var q0 = [[63,65],[-148,-146]]
-    var ex0 = [
-      { type: 'node', lat: 64.5, lon: -147.3,
-        id: names.A, version: versions.A },
-      { type: 'node', lat: 63.9, lon: -147.6,
-        id: names.B, version: versions.B },
-      { type: 'node', lat: 64.2, lon: -146.5,
-        id: names.C, version: versions.C },
-      { deleted: true, id: names.D, version: versions.G },
-      { type: 'way', refs: [ names.A, names.B, names.C ],
-        id: names.E, version: versions.F }
-    ].sort(idcmp)
-    osm.query(q0, function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex0, 'full coverage query')
-    })
-    collect(osm.queryStream(q0), function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex0, 'full coverage stream')
-    })
-    var q1 = [[62,64],[-149.5,-147.5]]
-    var ex1 = [
-      { type: 'node', lat: 64.5, lon: -147.3,
-        id: names.A, version: versions.A },
-      { type: 'node', lat: 63.9, lon: -147.6,
-        id: names.B, version: versions.B },
-      { type: 'node', lat: 64.2, lon: -146.5,
-        id: names.C, version: versions.C },
-      { deleted: true, id: names.D, version: versions.G },
       { type: 'way', refs: [ names.A, names.B, names.C ],
         id: names.E, version: versions.F }
     ].sort(idcmp)

--- a/test/del_relation.js
+++ b/test/del_relation.js
@@ -23,7 +23,7 @@ test('del relation', function (t) {
     B: { type: 'node', lat: 63.9, lon: -147.6 },
     C: { type: 'node', lat: 64.2, lon: -146.5 },
     D: { type: 'way', refs: [ 'A', 'B', 'C' ] },
-    E: { type: 'relation', refs: [ 'A', 'B', 'D' ] },
+    E: { type: 'relation', members: [ 'A', 'B', 'D' ] },
     F: { d: 'E' }
   }
   var names = {}
@@ -37,6 +37,9 @@ test('del relation', function (t) {
     var doc = docs[key]
     if (doc.refs) {
       doc.refs = doc.refs.map(function (ref) { return names[ref] })
+    }
+    if (doc.members) {
+      doc.members = doc.members.map(function (ref) { return names[ref] })
     }
     if (doc.d) {
       osm.del(names[doc.d], function (err, node) {
@@ -93,8 +96,8 @@ test('del relation in relation', function (t) {
     B: { type: 'node', lat: 63.9, lon: -147.6 },
     C: { type: 'node', lat: 64.2, lon: -146.5 },
     D: { type: 'way', refs: [ 'A', 'B', 'C' ] },
-    E: { type: 'relation', refs: [ 'A', 'B', 'D' ] },
-    F: { type: 'relation', refs: [ 'A', 'E', 'D' ] },
+    E: { type: 'relation', members: [ 'A', 'B', 'D' ] },
+    F: { type: 'relation', members: [ 'A', 'E', 'D' ] },
     G: { d: 'F' },
   }
   var names = {}
@@ -108,6 +111,9 @@ test('del relation in relation', function (t) {
     var doc = docs[key]
     if (doc.refs) {
       doc.refs = doc.refs.map(function (ref) { return names[ref] })
+    }
+    if (doc.members) {
+      doc.members = doc.members.map(function (ref) { return names[ref] })
     }
     if (doc.d) {
       osm.del(names[doc.d], function (err, node) {
@@ -138,7 +144,7 @@ test('del relation in relation', function (t) {
         id: names.C, version: versions.C },
       { type: 'way', refs: [names.A, names.B, names.C],
         id: names.D, version: versions.D },
-      { type: 'relation', refs: [names.A, names.B, names.D],
+      { type: 'relation', members: [names.A, names.B, names.D],
         id: names.E, version: versions.E },
       { deleted: true, id: names.F, version: versions.G }
     ].sort(idcmp)

--- a/test/del_relation.js
+++ b/test/del_relation.js
@@ -10,8 +10,9 @@ var storefile = path.join(tmpdir, 'osm-store-' + Math.random())
 
 var osmdb = require('../')
 
-test('delete a node from a way + modify way to remove node', function (t) {
-  t.plan(19)
+test('del relation', function (t) {
+  t.plan(10)
+
   var osm = osmdb({
     log: hyperlog(memdb(), { valueEncoding: 'json' }),
     db: memdb(),
@@ -21,10 +22,9 @@ test('delete a node from a way + modify way to remove node', function (t) {
     A: { type: 'node', lat: 64.5, lon: -147.3 },
     B: { type: 'node', lat: 63.9, lon: -147.6 },
     C: { type: 'node', lat: 64.2, lon: -146.5 },
-    D: { type: 'node', lat: 64.123, lon: -147.56 },
-    E: { type: 'way', refs: [ 'A', 'B', 'C', 'D' ] },
-    F: { m: 'E', v: { type: 'way', refs: [ 'A', 'B', 'C' ] } },
-    G: { d: 'D' }
+    D: { type: 'way', refs: [ 'A', 'B', 'C' ] },
+    E: { type: 'relation', refs: [ 'A', 'B', 'D' ] },
+    F: { d: 'E' }
   }
   var names = {}
   var nodes = {}
@@ -43,14 +43,6 @@ test('delete a node from a way + modify way to remove node', function (t) {
         t.ifError(err)
         versions[key] = node.key
         nodes[doc.d] = node
-        next()
-      })
-    } else if (doc.m) {
-      doc.v.refs = doc.v.refs.map(function (ref) { return names[ref] })
-      osm.put(names[doc.m], doc.v, function (err, node) {
-        t.ifError(err)
-        versions[key] = node.key
-        nodes[names[doc.m]] = node
         next()
       })
     } else {
@@ -73,9 +65,9 @@ test('delete a node from a way + modify way to remove node', function (t) {
         id: names.B, version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
         id: names.C, version: versions.C },
-      { type: 'way', refs: [ names.A, names.B, names.C ],
-        id: names.E, version: versions.F },
-      { deleted: true, id: names.D, version: versions.G },
+      { type: 'way', refs: [names.A, names.B, names.C],
+        id: names.D, version: versions.D },
+      { deleted: true, id: names.E, version: versions.F }
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
       t.ifError(err)
@@ -84,41 +76,13 @@ test('delete a node from a way + modify way to remove node', function (t) {
     collect(osm.queryStream(q0), function (err, res) {
       t.ifError(err)
       t.deepEqual(res.sort(idcmp), ex0, 'full coverage stream')
-    })
-    var q1 = [[62,64],[-149.5,-147.5]]
-    var ex1 = [
-      { type: 'node', lat: 64.5, lon: -147.3,
-        id: names.A, version: versions.A },
-      { type: 'node', lat: 63.9, lon: -147.6,
-        id: names.B, version: versions.B },
-      { type: 'node', lat: 64.2, lon: -146.5,
-        id: names.C, version: versions.C },
-      { type: 'way', refs: [ names.A, names.B, names.C ],
-        id: names.E, version: versions.F }
-    ].sort(idcmp)
-    osm.query(q1, function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex1, 'partial coverage query')
-    })
-    collect(osm.queryStream(q1), function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex1, 'partial coverage stream')
-    })
-    var q2 = [[62,64],[-147,-145]]
-    var ex2 = []
-    osm.query(q2, function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex2, 'empty coverage query')
-    })
-    collect(osm.queryStream(q2), function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex2, 'empty coverage stream')
     })
   }
 })
 
-test('delete a node from a way', function (t) {
-  t.plan(18)
+test('del relation in relation', function (t) {
+  t.plan(11)
+
   var osm = osmdb({
     log: hyperlog(memdb(), { valueEncoding: 'json' }),
     db: memdb(),
@@ -128,9 +92,10 @@ test('delete a node from a way', function (t) {
     A: { type: 'node', lat: 64.5, lon: -147.3 },
     B: { type: 'node', lat: 63.9, lon: -147.6 },
     C: { type: 'node', lat: 64.2, lon: -146.5 },
-    D: { type: 'node', lat: 64.123, lon: -147.56 },
-    E: { type: 'way', refs: [ 'A', 'B', 'C', 'D' ] },
-    F: { d: 'D' }
+    D: { type: 'way', refs: [ 'A', 'B', 'C' ] },
+    E: { type: 'relation', refs: [ 'A', 'B', 'D' ] },
+    F: { type: 'relation', refs: [ 'A', 'E', 'D' ] },
+    G: { d: 'F' },
   }
   var names = {}
   var nodes = {}
@@ -149,14 +114,6 @@ test('delete a node from a way', function (t) {
         t.ifError(err)
         versions[key] = node.key
         nodes[doc.d] = node
-        next()
-      })
-    } else if (doc.m) {
-      doc.v.refs = doc.v.refs.map(function (ref) { return names[ref] })
-      osm.put(names[doc.m], doc.v, function (err, node) {
-        t.ifError(err)
-        versions[key] = node.key
-        nodes[names[doc.m]] = node
         next()
       })
     } else {
@@ -179,9 +136,11 @@ test('delete a node from a way', function (t) {
         id: names.B, version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
         id: names.C, version: versions.C },
-      { deleted: true, id: names.D, version: versions.F },
-      { type: 'way', refs: [ names.A, names.B, names.C, names.D ],
-        id: names.E, version: versions.E }
+      { type: 'way', refs: [names.A, names.B, names.C],
+        id: names.D, version: versions.D },
+      { type: 'relation', refs: [names.A, names.B, names.D],
+        id: names.E, version: versions.E },
+      { deleted: true, id: names.F, version: versions.G }
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
       t.ifError(err)
@@ -190,36 +149,6 @@ test('delete a node from a way', function (t) {
     collect(osm.queryStream(q0), function (err, res) {
       t.ifError(err)
       t.deepEqual(res.sort(idcmp), ex0, 'full coverage stream')
-    })
-    var q1 = [[62,64],[-149.5,-147.5]]
-    var ex1 = [
-      { type: 'node', lat: 64.5, lon: -147.3,
-        id: names.A, version: versions.A },
-      { type: 'node', lat: 63.9, lon: -147.6,
-        id: names.B, version: versions.B },
-      { type: 'node', lat: 64.2, lon: -146.5,
-        id: names.C, version: versions.C },
-      { deleted: true, id: names.D, version: versions.F },
-      { type: 'way', refs: [ names.A, names.B, names.C, names.D ],
-        id: names.E, version: versions.E }
-    ].sort(idcmp)
-    osm.query(q1, function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex1, 'partial coverage query')
-    })
-    collect(osm.queryStream(q1), function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex1, 'partial coverage stream')
-    })
-    var q2 = [[62,64],[-147,-145]]
-    var ex2 = []
-    osm.query(q2, function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex2, 'empty coverage query')
-    })
-    collect(osm.queryStream(q2), function (err, res) {
-      t.ifError(err)
-      t.deepEqual(res.sort(idcmp), ex2, 'empty coverage stream')
     })
   }
 })

--- a/test/del_way.js
+++ b/test/del_way.js
@@ -58,12 +58,6 @@ test('del way', function (t) {
   function ready () {
     var q0 = [[63,65],[-148,-146]]
     var ex0 = [
-      { type: 'node', lat: 64.5, lon: -147.3,
-        id: names.A, version: versions.A },
-      { type: 'node', lat: 63.9, lon: -147.6,
-        id: names.B, version: versions.B },
-      { type: 'node', lat: 64.2, lon: -146.5,
-        id: names.C, version: versions.C },
       { deleted: true, id: names.D, version: versions.E }
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
@@ -77,12 +71,6 @@ test('del way', function (t) {
 
     var q1 = [[63,64],[-148,-146]]
     var ex1 = [
-      { type: 'node', lat: 64.5, lon: -147.3,
-        id: names.A, version: versions.A },
-      { type: 'node', lat: 63.9, lon: -147.6,
-        id: names.B, version: versions.B },
-      { type: 'node', lat: 64.2, lon: -146.5,
-        id: names.C, version: versions.C },
       { deleted: true, id: names.D, version: versions.E }
     ].sort(idcmp)
     osm.query(q1, function (err, res) {

--- a/test/del_way.js
+++ b/test/del_way.js
@@ -62,7 +62,8 @@ test('del way', function (t) {
       { type: 'node', lat: 63.9, lon: -147.6,
         id: names.B, version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
-        id: names.C, version: versions.C }
+        id: names.C, version: versions.C },
+      { deleted: true, id: names.D, version: versions.E }
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
       t.ifError(err)

--- a/test/del_way.js
+++ b/test/del_way.js
@@ -11,7 +11,8 @@ var storefile = path.join(tmpdir, 'osm-store-' + Math.random())
 var osmdb = require('../')
 
 test('del way', function (t) {
-  t.plan(9)
+  t.plan(13)
+
   var osm = osmdb({
     log: hyperlog(memdb(), { valueEncoding: 'json' }),
     db: memdb(),
@@ -72,6 +73,25 @@ test('del way', function (t) {
     collect(osm.queryStream(q0), function (err, res) {
       t.ifError(err)
       t.deepEqual(res.sort(idcmp), ex0, 'full coverage stream')
+    })
+
+    var q1 = [[63,64],[-148,-146]]
+    var ex1 = [
+      { type: 'node', lat: 64.5, lon: -147.3,
+        id: names.A, version: versions.A },
+      { type: 'node', lat: 63.9, lon: -147.6,
+        id: names.B, version: versions.B },
+      { type: 'node', lat: 64.2, lon: -146.5,
+        id: names.C, version: versions.C },
+      { deleted: true, id: names.D, version: versions.E }
+    ].sort(idcmp)
+    osm.query(q1, function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex0, 'partial coverage query')
+    })
+    collect(osm.queryStream(q1), function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex0, 'partial coverage stream')
     })
   }
 })

--- a/test/del_way_in_relation.js
+++ b/test/del_way_in_relation.js
@@ -1,0 +1,127 @@
+var test = require('tape')
+var hyperlog = require('hyperlog')
+var fdstore = require('fd-chunk-store')
+var path = require('path')
+var memdb = require('memdb')
+var collect = require('collect-stream')
+
+var tmpdir = require('os').tmpdir()
+var storefile = path.join(tmpdir, 'osm-store-' + Math.random())
+
+var osmdb = require('../')
+
+test('delete a way from a relation', function (t) {
+  t.plan(18)
+  var osm = osmdb({
+    log: hyperlog(memdb(), { valueEncoding: 'json' }),
+    db: memdb(),
+    store: fdstore(4096, storefile)
+  })
+  var docs = {
+    A: { type: 'node', lat: 64.5, lon: -147.3 },
+    B: { type: 'node', lat: 63.9, lon: -147.6 },
+    C: { type: 'node', lat: 64.2, lon: -146.5 },
+    D: { type: 'node', lat: 64.123, lon: -147.56 },
+    E: { type: 'way', refs: [ 'A', 'B', 'C', 'D' ] },
+    F: { d: 'E' },
+    G: { type: 'relation', refs: [ 'E' ] }
+  }
+  var names = {}
+  var nodes = {}
+  var versions = {}
+
+  var keys = Object.keys(docs).sort()
+  ;(function next () {
+    if (keys.length === 0) return ready()
+    var key = keys.shift()
+    var doc = docs[key]
+    if (doc.refs) {
+      doc.refs = doc.refs.map(function (ref) { return names[ref] })
+    }
+    if (doc.d) {
+      osm.del(names[doc.d], function (err, node) {
+        t.ifError(err)
+        versions[key] = node.key
+        nodes[doc.d] = node
+        next()
+      })
+    } else if (doc.m) {
+      doc.v.refs = doc.v.refs.map(function (ref) { return names[ref] })
+      osm.put(names[doc.m], doc.v, function (err, node) {
+        t.ifError(err)
+        versions[key] = node.key
+        nodes[names[doc.m]] = node
+        next()
+      })
+    } else {
+      osm.create(doc, function (err, k, node) {
+        t.ifError(err)
+        names[key] = k
+        versions[key] = node.key
+        nodes[k] = node
+        next()
+      })
+    }
+  })()
+
+  function ready () {
+    var q0 = [[63,65],[-148,-146]]
+    var ex0 = [
+      { type: 'node', lat: 64.5, lon: -147.3,
+        id: names.A, version: versions.A },
+      { type: 'node', lat: 63.9, lon: -147.6,
+        id: names.B, version: versions.B },
+      { type: 'node', lat: 64.2, lon: -146.5,
+        id: names.C, version: versions.C },
+      { type: 'node', lat: 64.123, lon: -147.56,
+        id: names.D, version: versions.D },
+      { deleted: true,// refs: [ names.A, names.B, names.C, names.D ],
+        id: names.E, version: versions.F },
+      { type: 'relation', refs: [ names.E ],
+        id: names.G, version: versions.G },
+    ].sort(idcmp)
+    osm.query(q0, function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex0, 'full coverage query')
+    })
+    collect(osm.queryStream(q0), function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex0, 'full coverage stream')
+    })
+    return
+    var q1 = [[62,64],[-149.5,-147.5]]
+    var ex1 = [
+      { type: 'node', lat: 64.5, lon: -147.3,
+        id: names.A, version: versions.A },
+      { type: 'node', lat: 63.9, lon: -147.6,
+        id: names.B, version: versions.B },
+      { type: 'node', lat: 64.2, lon: -146.5,
+        id: names.C, version: versions.C },
+      { deleted: true, id: names.D, version: versions.F },
+      { type: 'way', refs: [ names.A, names.B, names.C, names.D ],
+        id: names.E, version: versions.E }
+    ].sort(idcmp)
+    osm.query(q1, function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex1, 'partial coverage query')
+    })
+    collect(osm.queryStream(q1), function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex1, 'partial coverage stream')
+    })
+    var q2 = [[62,64],[-147,-145]]
+    var ex2 = []
+    osm.query(q2, function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex2, 'empty coverage query')
+    })
+    collect(osm.queryStream(q2), function (err, res) {
+      t.ifError(err)
+      t.deepEqual(res.sort(idcmp), ex2, 'empty coverage stream')
+    })
+  }
+})
+
+function idcmp (a, b) {
+  return a.id < b.id ? -1 : 1
+}

--- a/test/del_way_in_relation.js
+++ b/test/del_way_in_relation.js
@@ -70,14 +70,6 @@ test('delete a way from a relation', function (t) {
   function ready () {
     var q0 = [[63,65],[-148,-146]]
     var ex0 = [
-      { type: 'node', lat: 64.5, lon: -147.3,
-        id: names.A, version: versions.A },
-      { type: 'node', lat: 63.9, lon: -147.6,
-        id: names.B, version: versions.B },
-      { type: 'node', lat: 64.2, lon: -146.5,
-        id: names.C, version: versions.C },
-      { type: 'node', lat: 64.123, lon: -147.56,
-        id: names.D, version: versions.D },
       { deleted: true,
         id: names.E, version: versions.F },
       { type: 'relation', members: [ names.E ],
@@ -94,14 +86,6 @@ test('delete a way from a relation', function (t) {
 
     var q1 = [[62,64],[-149.5,-147.5]]
     var ex1 = [
-      { type: 'node', lat: 64.5, lon: -147.3,
-        id: names.A, version: versions.A },
-      { type: 'node', lat: 63.9, lon: -147.6,
-        id: names.B, version: versions.B },
-      { type: 'node', lat: 64.2, lon: -146.5,
-        id: names.C, version: versions.C },
-      { type: 'node', lat: 64.123, lon: -147.56,
-        id: names.D, version: versions.D },
       { deleted: true,
         id: names.E, version: versions.F },
       { type: 'relation', members: [ names.E ],

--- a/test/fork_del.js
+++ b/test/fork_del.js
@@ -65,5 +65,4 @@ test('forked node /w merging delete', function (t) {
       t.deepEqual(actual, expected, 'full coverage query')
     })
   }
-
 })

--- a/test/fork_del.js
+++ b/test/fork_del.js
@@ -1,0 +1,51 @@
+var test = require('tape')
+var hyperlog = require('hyperlog')
+var fdstore = require('fd-chunk-store')
+var path = require('path')
+var memdb = require('memdb')
+var collect = require('collect-stream')
+
+var tmpdir = require('os').tmpdir()
+var storefile = path.join(tmpdir, 'osm-store-' + Math.random())
+
+var osmdb = require('../')
+
+//       /-- A1 <--\
+// A <---           --- (deletion)
+//       \-- A2 <--/
+test('forked node /w merging delete', function (t) {
+  t.plan(11)
+
+  var osm = osmdb({
+    log: hyperlog(memdb(), { valueEncoding: 'json' }),
+    db: memdb(),
+    store: fdstore(4096, storefile)
+  })
+
+  var A = { type: 'node', lat: 0, lon: 0 }
+  var A1 = { type: 'node', lat: 1, lon: 1 }
+  var A2 = { type: 'node', lat: 2, lon: 2 }
+  osm.create(A, function (err, id, node0) {
+    t.ifError(err)
+    osm.put(id, A1, { links: [node0.key] }, function (err, node1) {
+      t.ifError(err)
+      t.deepEquals(node1.links, [node0.key], 'node1 links')
+      osm.put(id, A2, { links: [node0.key] }, function (err, node2) {
+        t.ifError(err)
+        t.deepEquals(node2.links, [node0.key], 'node2 links')
+        osm.del(id, function (err, delNode) {
+          t.ifError(err)
+          t.deepEquals(delNode.links, [node1.key, node2.key], 'del node links')
+          osm.get(id, function (err, docs) {
+            t.ifError(err)
+            t.equals(Object.keys(docs).length, 1)
+            var doc = docs[delNode.key]
+            t.equals(doc.deleted, true)
+            t.equals(doc.id, id)
+          })
+        })
+      })
+    })
+  })
+
+})

--- a/test/modify_batch.js
+++ b/test/modify_batch.js
@@ -52,8 +52,7 @@ test('del batch', function (t) {
         id: 'B', version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
         id: 'C', version: versions.C },
-      { deleted: true, lat: 64.123, lon: -147.56,
-        id: 'D', version: versions.D },
+      { deleted: true, id: 'D', version: versions.D },
       { type: 'way', refs: [ 'A', 'B', 'C' ],
         id: 'F', version: versions.F }
     ].sort(idcmp)

--- a/test/modify_batch.js
+++ b/test/modify_batch.js
@@ -38,7 +38,7 @@ test('del batch', function (t) {
     osm.batch(batch1, function (err, nodes) {
       t.error(err)
       nodes.forEach(function (node) {
-        versions[node.value.k] = node.key
+        versions[node.value.k || node.value.d] = node.key
       })
       ready()
     })
@@ -52,6 +52,8 @@ test('del batch', function (t) {
         id: 'B', version: versions.B },
       { type: 'node', lat: 64.2, lon: -146.5,
         id: 'C', version: versions.C },
+      { deleted: true, lat: 64.123, lon: -147.56,
+        id: 'D', version: versions.D },
       { type: 'way', refs: [ 'A', 'B', 'C' ],
         id: 'F', version: versions.F }
     ].sort(idcmp)

--- a/test/modify_way.js
+++ b/test/modify_way.js
@@ -92,10 +92,8 @@ test('modify way', function (t) {
         id: 'E', version: versions.E },
       { type: 'way', refs: ['A','E'],
         id: 'D', version: versions.D },
-      { deleted: true, id: 'B', version: deletions.B,
-        lat: 63.9, lon: -147.6 },
-      { deleted: true, id: 'C', version: deletions.C,
-        lat: 64.2, lon: -146.5 },
+      { deleted: true, id: 'B', version: deletions.B },
+      { deleted: true, id: 'C', version: deletions.C }
     ].sort(idcmp)
     osm.query(q2, function (err, res) {
       t.ifError(err)

--- a/test/modify_way.js
+++ b/test/modify_way.js
@@ -29,6 +29,7 @@ test('modify way', function (t) {
   ]
   var names = {}
   var versions = {}
+  var deletions = {}
 
   ;(function next () {
     if (docs.length === 0) return ready()
@@ -42,8 +43,9 @@ test('modify way', function (t) {
     }
     delete doc.links
     if (doc.type === 'del') {
-      osm.del(key, opts, function (err) {
+      osm.del(key, opts, function (err, node) {
         t.ifError(err)
+        deletions[key] = node.key
         next()
       })
     } else {
@@ -63,7 +65,7 @@ test('modify way', function (t) {
       { type: 'node', lat: 60.6, lon: -141.2,
         id: 'E', version: versions.E },
       { type: 'way', refs: ['A','E'],
-        id: 'D', version: versions.D }
+        id: 'D', version: versions.D },
     ].sort(idcmp)
     osm.query(q0, function (err, res) {
       t.ifError(err)
@@ -76,7 +78,7 @@ test('modify way', function (t) {
       { type: 'node', lat: 60.6, lon: -141.2,
         id: 'E', version: versions.E },
       { type: 'way', refs: ['A','E'],
-        id: 'D', version: versions.D }
+        id: 'D', version: versions.D },
     ].sort(idcmp)
     osm.query(q1, function (err, res) {
       t.ifError(err)
@@ -89,7 +91,11 @@ test('modify way', function (t) {
       { type: 'node', lat: 60.6, lon: -141.2,
         id: 'E', version: versions.E },
       { type: 'way', refs: ['A','E'],
-        id: 'D', version: versions.D }
+        id: 'D', version: versions.D },
+      { deleted: true, id: 'B', version: deletions.B,
+        lat: 63.9, lon: -147.6 },
+      { deleted: true, id: 'C', version: deletions.C,
+        lat: 64.2, lon: -146.5 },
     ].sort(idcmp)
     osm.query(q2, function (err, res) {
       t.ifError(err)

--- a/test/refbug.js
+++ b/test/refbug.js
@@ -57,8 +57,6 @@ test('refbug', function (t) {
       })
       t.deepEqual(node2, {
         id: 'n2',
-        lat: 64.6,
-        lon: -147.8,
         deleted: true,
         id: 'n2',
         version: deletions['n2']

--- a/test/split.js
+++ b/test/split.js
@@ -41,10 +41,22 @@ test('split', function (t) {
     var q = [[63,65],[-148,-145]]
     osm.query(q, function (err, res) {
       t.error(err)
-      var ids = res.map(function (r) { return r.id }).sort()
+      var docs = res.map(function (r) {
+        return [ r.id, r.deleted || false]
+      })
+      docs.sort(function cmp (a, b) {
+        return a[0] < b[0] ? -1 : 1
+      })
       var rows = {}
       res.forEach(function (r) { rows[r.id] = r })
-      t.deepEqual(ids, ['B','C','E','F'])
+      t.deepEqual(docs, [
+        ['A', true],
+        ['B', false],
+        ['C', false],
+        ['D', true],
+        ['E', false],
+        ['F', false]
+      ])
       t.deepEqual(rows.F.refs, ['B','C','E'])
     })
   }

--- a/test/split.js
+++ b/test/split.js
@@ -42,7 +42,7 @@ test('split', function (t) {
     osm.query(q, function (err, res) {
       t.error(err)
       var docs = res.map(function (r) {
-        return [ r.id, r.deleted || false]
+        return [ r.id, !!r.deleted ]
       })
       docs.sort(function cmp (a, b) {
         return a[0] < b[0] ? -1 : 1
@@ -50,7 +50,6 @@ test('split', function (t) {
       var rows = {}
       res.forEach(function (r) { rows[r.id] = r })
       t.deepEqual(docs, [
-        ['A', true],
         ['B', false],
         ['C', false],
         ['D', true],


### PR DESCRIPTION
# What?

To expose deleted OSM documents through the API in a way that corresponds to the underlying structure of the data model as closely as possible.

# Why?

osm-p2p-db makes no assumption about providing a single, "true" answer. The underlying data model is messy: forks and multiple versions of documents are both possible and valid states.

The OSM API itself assumes a linear history, which brings complication. A modular approach, with clear division of responsibilities makes sense:

- osm-p2p-db can provide a raw view into the true, messy data model
- downstream models, like osm-p2p-server, can perform transformations
on the forking data to produce a linear view of history, depending on
its parameters & preferences

This PR is to make this possible: expose forks and deletions in an explicit way in order to let downstream modules get a more honest view of the forking data they're working with.

# Changes?

Look at the diff for `README.md`; deleted documents are presented alongside non-deleted documents, via hyperkv.

These changes are breaking, and will require a major version bump.

# What's Next?

Start to break apart non-server logic in osm-p2p-server that does data linearization into a new module, osm-p2p-api.

From there, ripple these API changes out to osm-p2p-api, which can be solely responsible for making sense of non-linear data and explicit deletions, and express them to further downstream modules, like osm-p2p-server.