### PR TITLE
Store deleted documents in the refs index.

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,7 +339,10 @@ DB.prototype._onpt = function (pt, seen, cb) {
             deleted: true
           }
         }
-        addDoc(doc.value.k || doc.value.d, link, doc.value.v)
+        // TODO: open up this if() statement to expose deletions
+        if (doc.value.k) {
+          addDoc(doc.value.k || doc.value.d, link, doc.value.v)
+        }
         if (--pending === 0) cb(null, res)
       })
       pending++


### PR DESCRIPTION
This is a prerequisite for the larger goal of exposing deletions through the
osm-p2p-db API.

Like https://github.com/digidem/osm-p2p-db/pull/43, but for the `refs` index.
Also like the other pull request, although the logic for exposing deletions is
present, there is a temporary conditional to block it from bleeding out through
the API just yet. (Until https://github.com/digidem/osm-p2p-db/pull/44 does so.)