### PR TITLE
Return ways that are subsets of another way

### DIFF
--- a/index.js
+++ b/index.js
@@ -404,7 +404,7 @@ function cmpType (a, b) {
 DB.prototype._collectNodeAndReferers = function (version, seenAccum, cb) {
   cb = once(cb || noop)
   var self = this
-  if (seenAccum[version]) return cb(null, [])
+  if (seenAccum['deep'+version]) return cb(null, [])
   var res = []
   var added = {}
   var pending = 1
@@ -430,7 +430,7 @@ DB.prototype._collectNodeAndReferers = function (version, seenAccum, cb) {
     // on the map: add it.
     if (links.length === 0 && selfNode && !seenAccum[selfNode.key]) {
       addDocFromNode(selfNode)
-      seenAccum[selfNode.key] = true
+      seenAccum['deep'+selfNode.key] = true
     }
     selfNode = null
 
@@ -484,7 +484,7 @@ DB.prototype._collectNodeAndReferers = function (version, seenAccum, cb) {
   }
 
   function addDoc (id, version, doc) {
-    if (!added[version]) {
+    if (!added[version] && !seenAccum['deep'+version]) {
       doc = xtend(doc, {
         id: id,
         version: version

--- a/test/query_way.js
+++ b/test/query_way.js
@@ -54,6 +54,56 @@ test('ordered types - node in bbox returns linked way and refs nodes', function 
   }
 })
 
+test('multiple ways sharing nodes', function (t) {
+  t.plan(7)
+
+  var osm = makeOsm()
+
+  var rows = [
+    { type: 'put', key: 'A', value: {"type":"node","lon":-72.0929645381262,"lat":-4.5449438441953305} },
+    { type: 'put', key: 'B', value: {"type":"node","lon":-72.0926898458029,"lat":-4.544872757296443} },
+    { type: 'put', key: 'C', value: {"type":"node","lon":-72.09261644856267,"lat":-4.544951058228343} },
+    { type: 'put', key: 'D', value: {"type":"node","lon":-72.09288826173976,"lat":-4.544873517911439} },
+    { type: 'put', key: 'E', value: {"type":"node","lon":-72.09278144735785,"lat":-4.5447750358021795} },
+    { type: 'put', key: 'F', value: {"type":"way","refs":["A","D","B","E","C"],"tags":{"waterway":"river"}} },
+    { type: 'put', key: 'G', value: {"type":"way","refs":["D","E"],"tags":{"waterway":"spring"}} },
+  ]
+
+  osm.batch(rows, function (err, nodes) {
+    t.error(err)
+    osm.ready(function () { query(nodes) })
+  })
+
+  function query (nodes) {
+    // var q0 = [[-100, 100], [-100, 100]]
+    var q0 = [[-4.565473550710253,-4.5435702793717345],[-72.11425781250001,-72.09228515625001]]
+    var ext0 = [ 'node', 'node', 'node', 'node', 'node', 'way', 'way' ]
+    var ex0 = [
+      {"id":"A","type":"node","lon":-72.0929645381262,"lat":-4.5449438441953305},
+      {"id":"B","type":"node","lon":-72.0926898458029,"lat":-4.544872757296443},
+      {"id":"C","type":"node","lon":-72.09261644856267,"lat":-4.544951058228343},
+      {"id":"D","type":"node","lon":-72.09288826173976,"lat":-4.544873517911439},
+      {"id":"E","type":"node","lon":-72.09278144735785,"lat":-4.5447750358021795},
+      {"id":"F","type":"way","refs":["A","D","B","E","C"],"tags":{"waterway":"river"}},
+      {"id":"G","type":"way","refs":["D","E"],"tags":{"waterway":"spring"}}
+    ].sort(idcmp)
+
+    osm.query(q0, { order: 'type' }, function (err, res) {
+      t.error(err)
+      res.forEach(function (elm) { delete elm.version })
+      t.deepEqual(res.map(type), ext0, 'types')
+      t.deepEqual(res.sort(idcmp), ex0, 'results')
+    })
+    collect(osm.queryStream(q0, { order: 'type' }), function (err, res) {
+      t.error(err)
+      console.log('res', res)
+      res.forEach(function (elm) { delete elm.version })
+      t.deepEqual(res.map(type), ext0, 'types')
+      t.deepEqual(res.sort(idcmp), ex0, 'results')
+    })
+  }
+})
+
 function type (x) { return x.type }
 function idcmp (a, b) {
   return a.type === b.type


### PR DESCRIPTION
The fix was to ensure that every node in the bounding box was visited recursively. Before we'd skip the visit if the node was seen before (e.g. via traversing another way), preventing a full traversal of the visible data.

Addresses #57.